### PR TITLE
Added go-doc comments to exported functions

### DIFF
--- a/ntm.go
+++ b/ntm.go
@@ -283,6 +283,9 @@ type SGDMomentum struct {
 	PrevD []float64
 }
 
+// NewSDGMomentun creates a new instance of a stochastic gradient descent with momentum object with the
+// Controller object passed as an argument and a new slice as the PrevD with the length of the controllers
+// Weights Values
 func NewSGDMomentum(c Controller) *SGDMomentum {
 	s := SGDMomentum{
 		C:     c,
@@ -312,6 +315,7 @@ type RMSProp struct {
 	D []float64
 }
 
+// NewRMSProp creates a new instance of the rmsprop algorithm based on the controller given as an argumwnt
 func NewRMSProp(c Controller) *RMSProp {
 	r := RMSProp{
 		C: c,

--- a/ntm.go
+++ b/ntm.go
@@ -315,7 +315,7 @@ type RMSProp struct {
 	D []float64
 }
 
-// NewRMSProp creates a new instance of the rmsprop algorithm based on the controller given as an argumwnt
+// NewRMSProp creates a new instance of the rmsprop algorithm based on the controller given as an argument
 func NewRMSProp(c Controller) *RMSProp {
 	r := RMSProp{
 		C: c,

--- a/unit.go
+++ b/unit.go
@@ -10,6 +10,7 @@ type Unit struct {
 	Grad float64 // gradient at node
 }
 
+// String prints the value and gradient at a node in a neural network
 func (u Unit) String() string {
 	return fmt.Sprintf("{%.3g %.3g}", u.Val, u.Grad)
 }


### PR DESCRIPTION
Hi @fumin et al!

Since you [merged](https://github.com/fumin/ntm/pull/6) we thought we'd see what else CodeLingo could do for you.

The fix (which I found with [this tenet](https://www.codelingo.io/tenets/codelingo/effective-go/comment-first-word-when-empty)) just makes sure all exported functions are commented in the go-doc style. While this is a small issue it demonstrates how CodeLingo can be used to find hundreds of instances of an issue across multiple files in seconds, so nothing slips through the cracks.

<details>

<summary>Here's the full list of exported functions that i found using the CodeLingo review flow with just this one tenet.
</summary>

[unit.go#L13](https://github.com/fumin/ntm/blob/master/unit.go#L13)
[ntm_test.go#L8](https://github.com/fumin/ntm/blob/master/ntm_test.go#L8)
[addressing_test.go#L19](https://github.com/fumin/ntm/blob/master/addressing_test.go#L19)
[cntl1.go#L243](https://github.com/fumin/ntm/blob/master/cntl1.go#L243)
[cntl1.go#L105](https://github.com/fumin/ntm/blob/master/cntl1.go#L105)
[cntl1.go#L129](https://github.com/fumin/ntm/blob/master/cntl1.go#L129)
[cntl1.go#L97](https://github.com/fumin/ntm/blob/master/cntl1.go#L97)
[cntl1.go#L239](https://github.com/fumin/ntm/blob/master/cntl1.go#L239)
[cntl1.go#L133](https://github.com/fumin/ntm/blob/master/cntl1.go#L133)
[cntl1.go#L188](https://github.com/fumin/ntm/blob/master/cntl1.go#L188)
[cntl1.go#L101](https://github.com/fumin/ntm/blob/master/cntl1.go#L101)
[cntl1.go#L93](https://github.com/fumin/ntm/blob/master/cntl1.go#L93)
[cntl1.go#L214](https://github.com/fumin/ntm/blob/master/cntl1.go#L214)
[cntl1.go#L125](https://github.com/fumin/ntm/blob/master/cntl1.go#L125)
[cntl1.go#L218](https://github.com/fumin/ntm/blob/master/cntl1.go#L218)
[cntl1.go#L137](https://github.com/fumin/ntm/blob/master/cntl1.go#L137)
[cntl1.go#L210](https://github.com/fumin/ntm/blob/master/cntl1.go#L210)
[cntl1.go#L235](https://github.com/fumin/ntm/blob/master/cntl1.go#L235)
[ntm.go#L39](https://github.com/fumin/ntm/blob/master/ntm.go#L39)
[ntm.go#L66](https://github.com/fumin/ntm/blob/master/ntm.go#L66)
[ntm.go#L419](https://github.com/fumin/ntm/blob/master/ntm.go#L419)
[ntm.go#L294](https://github.com/fumin/ntm/blob/master/ntm.go#L294)
[ntm.go#L325](https://github.com/fumin/ntm/blob/master/ntm.go#L325)
[ntm.go#L315](https://github.com/fumin/ntm/blob/master/ntm.go#L315)
[ntm.go#L75](https://github.com/fumin/ntm/blob/master/ntm.go#L75)
[ntm.go#L84](https://github.com/fumin/ntm/blob/master/ntm.go#L84)
[ntm.go#L93](https://github.com/fumin/ntm/blob/master/ntm.go#L93)
[ntm.go#L48](https://github.com/fumin/ntm/blob/master/ntm.go#L48)
[ntm.go#L57](https://github.com/fumin/ntm/blob/master/ntm.go#L57)
[ntm.go#L286](https://github.com/fumin/ntm/blob/master/ntm.go#L286)
[cntl1_test.go#L69](https://github.com/fumin/ntm/blob/master/cntl1_test.go#L69)
[cntl1_test.go#L9](https://github.com/fumin/ntm/blob/master/cntl1_test.go#L9)
[cntl1_test.go#L38](https://github.com/fumin/ntm/blob/master/cntl1_test.go#L38)
[addressing.go#L321](https://github.com/fumin/ntm/blob/master/addressing.go#L321)
[addressing.go#L202](https://github.com/fumin/ntm/blob/master/addressing.go#L202)
[addressing.go#L41](https://github.com/fumin/ntm/blob/master/addressing.go#L41)
[addressing.go#L527](https://github.com/fumin/ntm/blob/master/addressing.go#L527)
[addressing.go#L145](https://github.com/fumin/ntm/blob/master/addressing.go#L145)
[addressing.go#L111](https://github.com/fumin/ntm/blob/master/addressing.go#L111)
[addressing.go#L78](https://github.com/fumin/ntm/blob/master/addressing.go#L78)
[addressing.go#L492](https://github.com/fumin/ntm/blob/master/addressing.go#L492)
[addressing.go#L291](https://github.com/fumin/ntm/blob/master/addressing.go#L291)
[ngram/ngram.go#L43](https://github.com/fumin/ntm/blob/master/ngram/ngram.go#L43)
[ngram/ngram.go#L18](https://github.com/fumin/ntm/blob/master/ngram/ngram.go#L18)
[copytask/copytask.go#L7](https://github.com/fumin/ntm/blob/master/copytask/copytask.go#L7)
[poem/poem.go#L106](https://github.com/fumin/ntm/blob/master/poem/poem.go#L106)
[poem/poem.go#L49](https://github.com/fumin/ntm/blob/master/poem/poem.go#L49)
[poem/poem.go#L29](https://github.com/fumin/ntm/blob/master/poem/poem.go#L29)
[poem/poem.go#L122](https://github.com/fumin/ntm/blob/master/poem/poem.go#L122)
[poem/poem.go#L166](https://github.com/fumin/ntm/blob/master/poem/poem.go#L166)
[poem/poem.go#L131](https://github.com/fumin/ntm/blob/master/poem/poem.go#L131)
[poem/poem.go#L112](https://github.com/fumin/ntm/blob/master/poem/poem.go#L112)
[poem/poem.go#L118](https://github.com/fumin/ntm/blob/master/poem/poem.go#L118)
[ntm.go#L61](https://github.com/fumin/ntm/blob/master/ntm.go#L61)
[poem/poem.go#L158](https://github.com/fumin/ntm/blob/master/poem/poem.go#L158)
[ntm.go#L70](https://github.com/fumin/ntm/blob/master/ntm.go#L70)
[poem/poem.go#L164](https://github.com/fumin/ntm/blob/master/poem/poem.go#L164)
[ntm.go#L52](https://github.com/fumin/ntm/blob/master/ntm.go#L52)
[poem/poem.go#L165](https://github.com/fumin/ntm/blob/master/poem/poem.go#L165)
[ntm.go#L79](https://github.com/fumin/ntm/blob/master/ntm.go#L79)
[ntm.go#L88](https://github.com/fumin/ntm/blob/master/ntm.go#L88)
[repeatcopy/repeatcopy.go#L18](https://github.com/fumin/ntm/blob/master/repeatcopy/repeatcopy.go#L18)
[repeatcopy/repeatcopy.go#L77](https://github.com/fumin/ntm/blob/master/repeatcopy/repeatcopy.go#L77)
[ntm.go#L61](https://github.com/fumin/ntm/blob/master/ntm.go#L61)
[ntm.go#L70](https://github.com/fumin/ntm/blob/master/ntm.go#L70)
[ntm.go#L52](https://github.com/fumin/ntm/blob/master/ntm.go#L52)
[ntm.go#L79](https://github.com/fumin/ntm/blob/master/ntm.go#L79)
[ntm.go#L88](https://github.com/fumin/ntm/blob/master/ntm.go#L88)
[repeatcopy/repeatcopy.go#L18](https://github.com/fumin/ntm/blob/master/repeatcopy/repeatcopy.go#L18)
[repeatcopy/repeatcopy.go#L77](https://github.com/fumin/ntm/blob/master/repeatcopy/repeatcopy.go#L77)

</details>

So you can hopefully see, CodeLingo is quite flexible. What bugs would you be keen to see us squash? We've got a [tiny form](https://docs.google.com/forms/d/e/1FAIpQLSeZQGVTH9eT629nXb5OGYok_Qd_mdJozLz1zYdTTL5LhBGEBQ/viewform) to capture bug fixing ideas if you come up with any 😄

Thanks,
Callan